### PR TITLE
Fix bug: Omega_m -> omega_m

### DIFF
--- a/FastPMRunner/lua_template.py
+++ b/FastPMRunner/lua_template.py
@@ -40,7 +40,7 @@ time_step = linspace({time_start}, {time_end}, {timesteps})
 output_redshifts= {{9.0, 2.0, 1.0, 0.0}}  -- redshifts of output
 
 -- Cosmology --
-Omega_m = {omega_m}
+omega_m = {omega_m}
 h       = {h}
 scalar_amp = {scalar_amp}
 scalar_spectral_index = {scalar_spectral_index}

--- a/FastPMRunner/simulationic.py
+++ b/FastPMRunner/simulationic.py
@@ -189,7 +189,7 @@ class SimulationICs(object):
 
     def set_powerspec(self):
         """Set power spectrum"""
-        self._scale_factors = np.linspace(self.time_start, self.time_end, self.timesteps)
+        self._scale_factors = np.linspace(self.time_start, self.time_end, self.timesteps + 1)
 
         powerspec_fn = lambda scale_factor: "{}_{:.4f}.txt".format(self.write_powerspectrum, scale_factor)
 


### PR DESCRIPTION
Two bugs happened in the previous PR merged:

1. Omega_m should be omega_m
2. timesteps for powerspec should +1
